### PR TITLE
ENH use compatible version for civis-jupyter-notebook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
 RUN pip install civis-jupyter-notebook~=${CIVIS_JUPYTER_NOTEBOOK_VERSION} && \
-    civis-jupyter-notebooks-install 
+    civis-jupyter-notebooks-install
 
 EXPOSE 8888
 WORKDIR /root/work

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
 RUN pip install civis-jupyter-notebook~=${CIVIS_JUPYTER_NOTEBOOK_VERSION} && \
-    civis-jupyter-notebooks-install
+    civis-jupyter-notebooks-install 
 
 EXPOSE 8888
 WORKDIR /root/work

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,13 @@ ENV VERSION= \
     VERSION_MICRO= \
     TINI_VERSION=v0.16.1 \
     DEFAULT_KERNEL=python3 \
-    CIVIS_JUPYTER_NOTEBOOK_VERSION=0.1.0
+    CIVIS_JUPYTER_NOTEBOOK_VERSION=0.1
 
 # Install Tini
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-RUN pip install civis-jupyter-notebook==${CIVIS_JUPYTER_NOTEBOOK_VERSION} && \
+RUN pip install civis-jupyter-notebook~=${CIVIS_JUPYTER_NOTEBOOK_VERSION} && \
     civis-jupyter-notebooks-install
 
 EXPOSE 8888


### PR DESCRIPTION
This PR switches us to a compatible version for civis-jupyter-notebook.