### PR TITLE
ENH update civis-jupyter-notebook to v0.2.0 and release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Changed requirement on `civis-jupyter-notebook` to only need a compatible version (#3).
 - `civis-jupyter-notebook` v0.1.0 -> v0.2.0 (#4).
+- Renamed `CHANGE_LOG.md` to `CHANGELOG.md`.
 
 ### Fixed
 - Incorrect entry in the change log (#2).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Changed requirement on `civis-jupyter-notebook` to only need a compatible version (#3).
 - `civis-jupyter-notebook` v0.1 -> v0.2 (#4).
-- Renamed `CHANGE_LOG.md` to `CHANGELOG.md`.
+- Renamed `CHANGE_LOG.md` to `CHANGELOG.md` (#4).
 
 ### Fixed
 - Incorrect entry in the change log (#2).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Changed requirement on `civis-jupyter-notebook` to only need a compatible version (#3).
-- `civis-jupyter-notebook` v0.1.0 -> v0.2.0 (#4).
+- `civis-jupyter-notebook` v0.1 -> v0.2 (#4).
 - Renamed `CHANGE_LOG.md` to `CHANGELOG.md`.
 
 ### Fixed

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.0] - 2017-09-13
+
+### Changed
+- Changed requirement on `civis-jupyter-notebook` to only need a compatible version (#3).
+- `civis-jupyter-notebook` v0.1.0 -> v0.2.0 (#4).
+
+### Fixed
+- Incorrect entry in the change log (#2).
+
 ## [1.0.0] - 2017-09-11
 
+### Added
 - Initial commit.

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV VERSION= \
     VERSION_MICRO= \
     TINI_VERSION=v0.16.1 \
     DEFAULT_KERNEL=python3 \
-    CIVIS_JUPYTER_NOTEBOOK_VERSION=0.1
+    CIVIS_JUPYTER_NOTEBOOK_VERSION=0.2
 
 # Install Tini
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini


### PR DESCRIPTION
This PR updates the version of civis-jupyter-notebook and preps for release v1.1.0