### PR TITLE
[CIVP-12451] Circle deploy artifact for releases

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,3 +10,11 @@ test:
   override:
     - docker run civisanalytics/civis-jupyter-python3 /bin/bash -c "echo BUILDS OK"
     - docker run civisanalytics/civis-jupyter-python3 python -c "import civis"
+
+deployment:
+  release:
+    tag: /v[0-9]+(\.[0-9]+)*/
+    commands:
+      - go get github.com/tcnksm/ghr
+      - docker run civisanalytics/civis-jupyter-python3 /bin/bash -c "pip freeze" > requirements.txt
+      - ghr -t $GITHUB_TOKEN -u civisanalytics -r civis-jupyter-python3 $CIRCLE_TAG requirements.txt


### PR DESCRIPTION
Not ready for merge yet. Needs to be modified to use S3 instead of Github.