### PR TITLE
Git integration with notebooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.1] - 2017-09-18
+
+## Changed
+- civis-jupyter-notebook v0.2.0 -> v0.2.2 (#5)
+- Use a full version number for civis-jupyter-notebook (#5, rolls back changes from #3).
+
 ## [1.1.0] - 2017-09-13
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV VERSION= \
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@1f11e56b105d27b93b88e5118eba96fd8b5bb45 && \
+RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@91576fca43189f4795286f916b9c71669c6c7cdd && \
     civis-jupyter-notebooks-install
 
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV VERSION= \
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@574c6831fc9fe8ba568e99f0c3fd8680902c21f8 && \
+RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@faf4e21033b0aec0625dc2faac10276a0a23afec && \
     civis-jupyter-notebooks-install
 
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV VERSION= \
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@13f084ee7bd99c07ab863bd5bc4da65385d93d18 && \
+RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@574c6831fc9fe8ba568e99f0c3fd8680902c21f8 && \
     civis-jupyter-notebooks-install
 
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV VERSION= \
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-RUN pip install git+https://github.com/civisanalytics/civis-jupyter-python3.git@750cb00158b79a9538058653861c09ba1076cc9f && \
+RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@750cb00158b79a9538058653861c09ba1076cc9f && \
     civis-jupyter-notebooks-install
 
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV VERSION= \
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@750cb00158b79a9538058653861c09ba1076cc9f && \
+RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@13f084ee7bd99c07ab863bd5bc4da65385d93d18 && \
     civis-jupyter-notebooks-install
 
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV VERSION= \
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@e73ae1c1ba1556662f0b38e3c059154d40a61335 && \
+RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@4f9c812b1b9bd8480043c5261309ddd951ef18cc && \
     civis-jupyter-notebooks-install
 
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV VERSION= \
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@c1e082f9e6a9a7c1606554dc016f2de69b0fc4cc && \
+RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@dccf0ce7204037844f0a63450fd2367dae36ca8e && \
     civis-jupyter-notebooks-install
 
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,13 @@ ENV VERSION= \
     VERSION_MICRO= \
     TINI_VERSION=v0.16.1 \
     DEFAULT_KERNEL=python3 \
-    CIVIS_JUPYTER_NOTEBOOK_VERSION=0.2.2
+    CIVIS_JUPYTER_NOTEBOOK_VERSION=0.2.3
 
 # Install Tini
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@4f9c812b1b9bd8480043c5261309ddd951ef18cc && \
+RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@0931ce8e289ef4e738ce3b6a5c3bc870a370d996 && \
     civis-jupyter-notebooks-install
 
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV VERSION= \
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@91576fca43189f4795286f916b9c71669c6c7cdd && \
+RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@3bf34eb2dbc36ea7f7db131fc41aced8dea79607 && \
     civis-jupyter-notebooks-install
 
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV VERSION= \
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@5ff00365dd4a8b92d261d652693d3d7d3a75141f && \
+RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@c1e082f9e6a9a7c1606554dc016f2de69b0fc4cc && \
     civis-jupyter-notebooks-install
 
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV VERSION= \
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@4555ee18342a7dfad6fe82cb386303b1d69452d8 && \
+RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@2d5d71daa4bc6d66c557a4eaa81a2081090eecf8 && \
     civis-jupyter-notebooks-install
 
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV VERSION= \
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@da3042697aac32ff63e44e86180cebc3fd15fda0 && \
+RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@1f11e56b105d27b93b88e5118eba96fd8b5bb45 && \
     civis-jupyter-notebooks-install
 
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV VERSION= \
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@faf4e21033b0aec0625dc2faac10276a0a23afec && \
+RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@e73ae1c1ba1556662f0b38e3c059154d40a61335 && \
     civis-jupyter-notebooks-install
 
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV VERSION= \
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@be70811509f33e3689a7eeaca15e6db7a706feda && \
+RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@4555ee18342a7dfad6fe82cb386303b1d69452d8 && \
     civis-jupyter-notebooks-install
 
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV VERSION= \
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@0931ce8e289ef4e738ce3b6a5c3bc870a370d996 && \
+RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@da3042697aac32ff63e44e86180cebc3fd15fda0 && \
     civis-jupyter-notebooks-install
 
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV VERSION= \
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@3bf34eb2dbc36ea7f7db131fc41aced8dea79607 && \
+RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@be70811509f33e3689a7eeaca15e6db7a706feda && \
     civis-jupyter-notebooks-install
 
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV VERSION= \
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-RUN pip install civis-jupyter-notebook==${CIVIS_JUPYTER_NOTEBOOK_VERSION} && \
+RUN pip install git+https://github.com/civisanalytics/civis-jupyter-python3.git@750cb00158b79a9538058653861c09ba1076cc9f && \
     civis-jupyter-notebooks-install
 
 EXPOSE 8888
@@ -23,4 +23,4 @@ WORKDIR /root/work
 
 # Configure container startup
 ENTRYPOINT ["/tini", "--"]
-CMD ["civis-jupyter-notebooks-start"] 
+CMD ["civis-jupyter-notebooks-start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV VERSION= \
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@2d5d71daa4bc6d66c557a4eaa81a2081090eecf8 && \
+RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@5ff00365dd4a8b92d261d652693d3d7d3a75141f && \
     civis-jupyter-notebooks-install
 
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,13 @@ ENV VERSION= \
     VERSION_MICRO= \
     TINI_VERSION=v0.16.1 \
     DEFAULT_KERNEL=python3 \
-    CIVIS_JUPYTER_NOTEBOOK_VERSION=0.2
+    CIVIS_JUPYTER_NOTEBOOK_VERSION=0.2.2
 
 # Install Tini
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-RUN pip install civis-jupyter-notebook~=${CIVIS_JUPYTER_NOTEBOOK_VERSION} && \
+RUN pip install civis-jupyter-notebook==${CIVIS_JUPYTER_NOTEBOOK_VERSION} && \
     civis-jupyter-notebooks-install
 
 EXPOSE 8888


### PR DESCRIPTION
This branch builds the Docker image for adding git integration with notebooks.  It should always point to the latest commit hash in this PR: civisanalytics/civis-jupyter-notebook#14.