### PR TITLE
DEP Update base image to datascience-python 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+## [1.2.0] - 2017-11-27
+
+## Changed
+- Update base datascience-python version to v3.3.0.
+
 ## [1.1.1] - 2017-09-18
 
 ## Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM civisanalytics/datascience-python:3.2.0
+FROM civisanalytics/datascience-python:3.3.0
 MAINTAINER support@civisanalytics.com
 
 # Version strings are set in datascience-python


### PR DESCRIPTION
Update the base Docker image the most recent datascience-python version (v3.3.0). Among other package updates, this will provide users access to the most recent Python API client version, v1.7.1. Release notes at https://github.com/civisanalytics/datascience-python/releases/tag/v3.3.0 .