### PR TITLE
BUG Use civis-jupyter-notebook which doesn't clobber dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [1.2.1] - 2017-11-28
+
+### Fixed
+- Increase ``civis-jupyter-notebook`` version from v0.2.2 to v0.2.4 to get bugfix with relaxed dependency requirements (#9).
+
 ## [1.2.0] - 2017-11-27
 
 ## Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV VERSION= \
     VERSION_MICRO= \
     TINI_VERSION=v0.16.1 \
     DEFAULT_KERNEL=python3 \
-    CIVIS_JUPYTER_NOTEBOOK_VERSION=0.2.2
+    CIVIS_JUPYTER_NOTEBOOK_VERSION=0.2.4
 
 # Install Tini
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini


### PR DESCRIPTION
The versions of `civis-jupyter-notebook` <0.2.4 have strict requirements which, for example, will force a downgrade to `civis==1.6`. Update to a bugfix version with more permissive requirements.