### PR TITLE
add civis matplotlib style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+- Add Civis matplotlib style (https://github.com/civisanalytics/civis-mpl-style).
+
 ## [1.2.1] - 2017-11-28
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN chmod +x /tini
 
 RUN pip install civis-jupyter-notebook==${CIVIS_JUPYTER_NOTEBOOK_VERSION} && \
     civis-jupyter-notebooks-install
+RUN pip install git+git://github.com/civisanalytics/civis-mpl-style.git@v0.1.0 && \
+    install-civis-style
 
 EXPOSE 8888
 WORKDIR /root/work


### PR DESCRIPTION
This adds the [Civis matplotlib style](https://github.com/civisanalytics/civis-mpl-style) to the docker image.

This could also be in [civis-jupyter-notebook](github.com/civisanalytics/civis-jupyter-notebook), but it seems unrelated to that functionality.  It also could be installed in the [datascience-python](https://github.com/civisanalytics/datascience-python) image, but this seems pretty notebook specific.  I don't have strong feelings about where to put this, but putting it here seems easiest.