### PR TITLE
MAINT Update datascience-python to 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Changed
+- Update base datascience-python version to v4.0.0 (#20)
+
 ## [1.5.2] - 2018-01-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [1.6.0] - 2018-01-25
 ### Changed
 - Update base datascience-python version to v4.0.0 (#20)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM civisanalytics/datascience-python:3.3.0
+FROM civisanalytics/datascience-python:4.0.0
 MAINTAINER support@civisanalytics.com
 
 # Version strings are set in datascience-python


### PR DESCRIPTION
The full changelog is at https://github.com/civisanalytics/datascience-python/releases/tag/v4.0.0 . A significant improvement is the update of `civis` to v1.8.0.