### PR TITLE
MAINT Update datascience-python to 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+
+
+## [1.7.0] - 2018-04-26
+### Changed
+- Update base datascience-python version to v4.2.0 (#22)
+
 ### Added
-- Installed htop and tmux
+- Installed htop and tmux (#21)
 
 ## [1.6.0] - 2018-01-25
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM civisanalytics/datascience-python:4.0.0
+FROM civisanalytics/datascience-python:4.2.0
 MAINTAINER support@civisanalytics.com
 
 # Version strings are set in datascience-python


### PR DESCRIPTION
The full changelog is at https://github.com/civisanalytics/datascience-python/releases/tag/v4.2.0 . A significant improvement is the update of civis to v1.9.0.