### PR TITLE
MAINT update datascience-python to 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+
+## [1.8.0] - 2019-03-13
 ### Changed
+- Update base datascience-python version to v5.0.0 (#24)
 - Migrate CircleCI build from v1.0 to v2.0 (#23)
 
 ## [1.7.0] - 2018-04-26

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM civisanalytics/datascience-python:4.2.0
+FROM civisanalytics/datascience-python:5.0.0
 MAINTAINER support@civisanalytics.com
 
 # Version strings are set in datascience-python


### PR DESCRIPTION
This PR updates the underlying datascience-python version so that notebooks and scripts use the same packages versions.