### PR TITLE
[CIVP-18029] Update datascience-python to v5.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN chmod +x /tini
 # RUN pip install civis-jupyter-notebook==${CIVIS_JUPYTER_NOTEBOOK_VERSION} && \
 #     civis-jupyter-notebooks-install
 
+# For development purposes, point to local dev branch
 RUN pip install git+git://github.com/civisanalytics/civis-jupyter-notebook@update-notebook-version
 
 RUN pip install git+git://github.com/civisanalytics/civis-mpl-style.git@v0.1.0 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,11 +26,12 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --no-install-recommends && 
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-RUN pip install civis-jupyter-notebook==${CIVIS_JUPYTER_NOTEBOOK_VERSION} && \
-   civis-jupyter-notebooks-install
+# RUN pip install civis-jupyter-notebook==${CIVIS_JUPYTER_NOTEBOOK_VERSION} && \
+#   civis-jupyter-notebooks-install
 
-# For development purposes, point to local dev branch - tornado 5.1.1
-# RUN pip install git+git://github.com/civisanalytics/civis-jupyter-notebook@master
+# For development purposes, point to local dev branch
+RUN pip install git+git://github.com/civisanalytics/civis-jupyter-notebook@update-notebook-version  && \
+   civis-jupyter-notebooks-install
 
 RUN pip install git+git://github.com/civisanalytics/civis-mpl-style.git@v0.1.0 && \
    install-civis-style

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN chmod +x /tini
 # RUN pip install civis-jupyter-notebook==${CIVIS_JUPYTER_NOTEBOOK_VERSION} && \
 #     civis-jupyter-notebooks-install
 
-# For development purposes, point to local dev branch
+# For development purposes, point to local dev branch - tornado 5.1.1
 RUN pip install git+git://github.com/civisanalytics/civis-jupyter-notebook@update-notebook-version
 
 RUN pip install git+git://github.com/civisanalytics/civis-mpl-style.git@v0.1.0 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,7 @@ RUN chmod +x /tini
 # RUN pip install civis-jupyter-notebook==${CIVIS_JUPYTER_NOTEBOOK_VERSION} && \
 #     civis-jupyter-notebooks-install
 
-RUN pip install git+git://github.com/civisanalytics/civis-jupyter-notebook@update-notebook-version && \
-    install-civis-style
+RUN pip install git+git://github.com/civisanalytics/civis-jupyter-notebook@update-notebook-version
 
 RUN pip install git+git://github.com/civisanalytics/civis-mpl-style.git@v0.1.0 && \
    install-civis-style

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,11 +26,11 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --no-install-recommends && 
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-# RUN pip install civis-jupyter-notebook==${CIVIS_JUPYTER_NOTEBOOK_VERSION} && \
-#     civis-jupyter-notebooks-install
+RUN pip install civis-jupyter-notebook==${CIVIS_JUPYTER_NOTEBOOK_VERSION} && \
+   civis-jupyter-notebooks-install
 
 # For development purposes, point to local dev branch - tornado 5.1.1
-RUN pip install git+git://github.com/civisanalytics/civis-jupyter-notebook@update-notebook-version
+# RUN pip install git+git://github.com/civisanalytics/civis-jupyter-notebook@master
 
 RUN pip install git+git://github.com/civisanalytics/civis-mpl-style.git@v0.1.0 && \
    install-civis-style

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM civisanalytics/datascience-python:4.2.0
+FROM civisanalytics/datascience-python:5.0.0
 MAINTAINER support@civisanalytics.com
 
 # Version strings are set in datascience-python
@@ -26,14 +26,18 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --no-install-recommends && 
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-RUN pip install civis-jupyter-notebook==${CIVIS_JUPYTER_NOTEBOOK_VERSION} && \
-    civis-jupyter-notebooks-install
-RUN pip install git+git://github.com/civisanalytics/civis-mpl-style.git@v0.1.0 && \
+# RUN pip install civis-jupyter-notebook==${CIVIS_JUPYTER_NOTEBOOK_VERSION} && \
+#     civis-jupyter-notebooks-install
+
+RUN pip install git+git://github.com/civisanalytics/civis-jupyter-notebook@update-notebook-version && \
     install-civis-style
+
+RUN pip install git+git://github.com/civisanalytics/civis-mpl-style.git@v0.1.0 && \
+   install-civis-style
 
 EXPOSE 8888
 WORKDIR /root/work
 
 # Configure container startup
 ENTRYPOINT ["/tini", "--"]
-CMD ["civis-jupyter-notebooks-start"] 
+CMD ["civis-jupyter-notebooks-start"]


### PR DESCRIPTION
This PR handles:
- Upgrade datascience-python to use v5.0.0
- Update civis-jupyter-notebook to [x.x.x] (version pending) - see PR here: https://github.com/civisanalytics/civis-jupyter-notebook/pull/37