### PR TITLE
[CIVP-18122] Upgrade civis-jupyter-notebook from 0.4.5 to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [1.11.0] - 2019-04-30
+### Changed
+- Update civis-jupyter-notebook version to v0.5.0 (#30)
+
 ## [1.10.0] - 2019-04-22
 ### Changed
 - Update base datascience-python version to v5.0.0 (#28)

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV VERSION= \
     VERSION_MICRO= \
     TINI_VERSION=v0.16.1 \
     DEFAULT_KERNEL=python3 \
-    CIVIS_JUPYTER_NOTEBOOK_VERSION=0.4.5
+    CIVIS_JUPYTER_NOTEBOOK_VERSION=0.5.0
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --no-install-recommends && \
   apt-get install -y --no-install-recommends software-properties-common && \


### PR DESCRIPTION
Upgrade civis-jupyter-notebook from 0.4.5 to 0.5.0 which has Bitbucket support. 