### PR TITLE
DEP update datascience-python to 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Changed
+- update base datascience-python version to v6.0.0 (#41)
 
 ## [1.12.2] - 2020-01-30
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM civisanalytics/datascience-python:5.0.0
+FROM civisanalytics/datascience-python:6.0.0
 MAINTAINER support@civisanalytics.com
 
 # Version strings are set in datascience-python


### PR DESCRIPTION
This PR updates the underlying datascience-python dependency to 6.0.0, to match the dependency versions used by Python scripts.