### PR TITLE
update base datascience-python version to v6.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [2.1.0] - 2020-04-23
+### Changed
+- update base datascience-python version to v6.2.1 (#43)
+
 ## [2.0.0] - 2020-02-18
 ### Changed
 - update base datascience-python version to v6.0.0 (#41)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM civisanalytics/datascience-python:6.0.0
+FROM civisanalytics/datascience-python:6.2.1
 MAINTAINER support@civisanalytics.com
 
 # Version strings are set in datascience-python


### PR DESCRIPTION
related to https://github.com/civisanalytics/datascience-python/pull/78

I tested this with a local image, and the API client seemed to work just fine.