### PR TITLE
Upgrade civis-jupyter-notebook to v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [2.2.0] - 2020-09-09
+### Changed
+- update civis-jupyter-notebook version to v2.0.0 (#45)
+
 ## [2.1.0] - 2020-04-23
 ### Changed
 - update base datascience-python version to v6.2.1 (#43)

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV VERSION= \
     VERSION_MICRO= \
     TINI_VERSION=v0.16.1 \
     DEFAULT_KERNEL=python3 \
-    CIVIS_JUPYTER_NOTEBOOK_VERSION=1.0.2
+    CIVIS_JUPYTER_NOTEBOOK_VERSION=2.0.0
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --no-install-recommends && \
   apt-get install -y --no-install-recommends software-properties-common && \


### PR DESCRIPTION
This PR upgrades the civis-jupyter-notebook package to [v2.0.0](https://github.com/civisanalytics/civis-jupyter-notebook/releases/tag/v2.0.0).  I don't expect any functional changes here, but I'm seeking to bump this repo a minor version so that we don't affect most existing notebooks in Platform, just in case.