### PR TITLE
[CIVP-22369] - bugfix python client release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [2.3.1] - 2020-11-13
+### Changed
+- update base datascience-python version to v6.3.1 (#47)
+
 ## [2.3.0] - 2020-09-30
 ### Changed
 - update base datascience-python version to v6.3.0 (#46)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM civisanalytics/datascience-python:6.3.0
+FROM civisanalytics/datascience-python:6.3.1
 MAINTAINER support@civisanalytics.com
 
 # Version strings are set in datascience-python


### PR DESCRIPTION
extends the bump of civis client version
requires merge and release of https://github.com/civisanalytics/datascience-python/pull/81