### PR TITLE
[CIVIS-1837] ENH update datascience-python base to 6.5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.6.5
+      - image: cimg/python:3.7
     steps:
       - checkout
       - setup_remote_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ jobs:
       - image: cimg/python:3.7
     steps:
       - checkout
-      - setup_remote_docker
       - run: docker build -t civisanalytics/civis-jupyter-python3 .
       - run: docker run civisanalytics/civis-jupyter-python3 /bin/bash -c "echo BUILDS OK"
       - run: docker run civisanalytics/civis-jupyter-python3 python -c "import civis"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
       - image: cimg/python:3.7
     steps:
       - checkout
+      - setup_remote_docker
       - run: docker build -t civisanalytics/civis-jupyter-python3 .
       - run: docker run civisanalytics/civis-jupyter-python3 /bin/bash -c "echo BUILDS OK"
       - run: docker run civisanalytics/civis-jupyter-python3 python -c "import civis"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [2.4.0] - 2021-12-14
+### Changed
+- update base datascience-python version to v6.5.0 (#48)
+
 ## [2.3.1] - 2020-11-13
 ### Changed
 - update base datascience-python version to v6.3.1 (#47)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM civisanalytics/datascience-python:6.3.1
+FROM civisanalytics/datascience-python:6.5.0
 MAINTAINER support@civisanalytics.com
 
 # Version strings are set in datascience-python


### PR DESCRIPTION
This PR updates the the datascience-python base image to tag 6.5.0. Also updating changelog to prepare for a new 2.5.0 release.