### PR TITLE
[CIVIS-1912] FIX update datascience-python base image to 6.5.1; prep for 2.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [2.4.1] - 2021-12-15
+### Changed
+- update base datascience-python version to v6.5.1 (#49)
+
 ## [2.4.0] - 2021-12-14
 ### Changed
 - update base datascience-python version to v6.5.0 (#48)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM civisanalytics/datascience-python:6.5.0
+FROM civisanalytics/datascience-python:6.5.1
 MAINTAINER support@civisanalytics.com
 
 # Version strings are set in datascience-python


### PR DESCRIPTION
This PR updates the datascience-python base image to 6.5.1. Also updating changelog for 2.4.1 release.