### PR TITLE
[CIVIS-6236] removes an extraneous command due to bad copy pasta

### DIFF
--- a/buildspec/merge_master.yaml
+++ b/buildspec/merge_master.yaml
@@ -9,7 +9,6 @@ phases:
       - echo Building the Docker image...
       - export DS_PYTHON_IMG_VERSION=$(head -n 1 ./.ds_python_version)
       - docker build --build-arg="DS_PYTHON_IMG_VERSION=${DS_PYTHON_IMG_VERSION}" -t ${REPOSITORY_URI}:latest -t civisanalytics/civis-jupyter-python3:latest .
-      - civisanalytics/civis-jupyter-python3
       - docker image push --all-tags ${REPOSITORY_URI}
       - docker image push --all-tags civisanalytics/civis-jupyter-python3
   post_build:


### PR DESCRIPTION
removes an overlooked an invalid command in the codebuild yaml config