### PR TITLE
[CIVIS-7585] Update civis-jupyter-notebook to fix terminal access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [3.1.1] - 2024-08-15
+### Fixed
+- Update civis-jupyter-notebook to v2.2.1 to fix terminal access (#55)
+
 ## [3.1.0] - 2024-06-18
 ### Changed
 - Updated base datascience-python image version to v7.3.0 (#54)

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG DS_PYTHON_IMG_VERSION=7.3.0
 
 FROM civisanalytics/datascience-python:${DS_PYTHON_IMG_VERSION}
 
-LABEL maintainer = support@civisanalytics.com
+LABEL maintainer=support@civisanalytics.com
 
 # Version strings are set in datascience-python
 # Set to blank strings here; they'd be misleading.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To execute these updates, follow these steps:
 * Run `sh generate-requirements-full.sh` to update `requirements-full.txt`.
 * To verify the new `civis-jupyter-python3` image would successfully build with your changes, locally run `sh build_docker_file.sh`.
 
-#### Making a New Releases
+#### Making a New Release
 
 This repo has autobuild enabled. Any PR that is merged to master will
 be built as the `latest` tag on Dockerhub.

--- a/buildspec/push.yaml
+++ b/buildspec/push.yaml
@@ -3,17 +3,17 @@ phases:
   build:
     commands:
       - echo Logging in to Amazon ECR...
-      - aws ecr get-login-password --region ${AWS_DEFAULT_REGION} | docker login --username AWS --password-stdin ${REPOSITORY_URI}
+      - aws ecr get-login-password --region ${AWS_DEFAULT_REGION} | docker login --username AWS --password-stdin ${FIPS_REPOSITORY_URI}
       - echo Logging into Docker Hub
       - echo $DOCKERHUB_PASSWORD | docker login --username ${DOCKERHUB_USERNAME} --password-stdin
       - export COMMIT_HASH_SHORT="$(echo $COMMIT_HASH | cut -c 1-7)"
       - echo Building the Docker image...
-      - echo $REPOSITORY_URI
+      - echo $FIPS_REPOSITORY_URI
       - echo $COMMIT_HASH_SHORT
       - echo $BRANCH_NAME
       - export DS_PYTHON_IMG_VERSION=$(head -n 1 ./.ds_python_version)
-      - docker build --build-arg="DS_PYTHON_IMG_VERSION=${DS_PYTHON_IMG_VERSION}" --tag ${REPOSITORY_URI}:${COMMIT_HASH_SHORT} --tag ${REPOSITORY_URI}:${BRANCH_NAME} --tag civisanalytics/civis-jupyter-python3:${BRANCH_NAME} .
-      - docker image push --all-tags ${REPOSITORY_URI}
+      - docker build --build-arg="DS_PYTHON_IMG_VERSION=${DS_PYTHON_IMG_VERSION}" --tag ${FIPS_REPOSITORY_URI}:${COMMIT_HASH_SHORT} --tag ${FIPS_REPOSITORY_URI}:${BRANCH_NAME} --tag civisanalytics/civis-jupyter-python3:${BRANCH_NAME} .
+      - docker image push --all-tags ${FIPS_REPOSITORY_URI}
       - docker image push --all-tags civisanalytics/civis-jupyter-python3
   post_build:
     commands:

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -1,3 +1,3 @@
-civis-jupyter-notebook==2.2.0
+civis-jupyter-notebook==2.2.1
 matplotlib==3.9.0
 seaborn==0.13.2

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -39,7 +39,7 @@ certifi==2024.6.2
     # via
     #   -r /tmp/requirements-aggregated-core.txt
     #   requests
-cffi==1.16.0
+cffi==1.17.0
     # via argon2-cffi-bindings
 charset-normalizer==3.3.2
     # via
@@ -52,7 +52,7 @@ civis==2.3.0
     #   civis-jupyter-notebook
 civis-jupyter-extensions==1.2.0
     # via civis-jupyter-notebook
-civis-jupyter-notebook==2.2.0
+civis-jupyter-notebook==2.2.1
     # via -r /tmp/requirements-aggregated-core.txt
 click==8.1.7
     # via
@@ -73,7 +73,7 @@ contourpy==1.2.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-debugpy==1.8.1
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -89,7 +89,7 @@ executing==2.0.1
     # via stack-data
 fastjsonschema==2.20.0
     # via nbformat
-fonttools==4.53.0
+fonttools==4.53.1
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
@@ -103,11 +103,11 @@ idna==3.7
     #   anyio
     #   jsonschema
     #   requests
-ipykernel==6.29.4
+ipykernel==6.29.5
     # via
     #   nbclassic
     #   notebook
-ipython==8.25.0
+ipython==8.26.0
     # via
     #   civis-jupyter-extensions
     #   ipykernel
@@ -168,7 +168,7 @@ jupyter-core==5.7.2
     #   notebook
 jupyter-events==0.10.0
     # via jupyter-server
-jupyter-server==2.14.1
+jupyter-server==2.14.2
     # via notebook-shim
 jupyter-server-terminals==0.5.3
     # via jupyter-server
@@ -242,7 +242,7 @@ parso==0.8.4
     # via jedi
 pexpect==4.9.0
     # via ipython
-pillow==10.3.0
+pillow==10.4.0
     # via matplotlib
 platformdirs==4.2.2
     # via jupyter-core
@@ -252,13 +252,13 @@ prometheus-client==0.20.0
     #   notebook
 prompt-toolkit==3.0.47
     # via ipython
-psutil==5.9.8
+psutil==6.0.0
     # via ipykernel
 ptyprocess==0.7.0
     # via
     #   pexpect
     #   terminado
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 pyasn1==0.6.0
     # via
@@ -292,7 +292,7 @@ pyyaml==6.0.1
     #   awscli
     #   civis
     #   jupyter-events
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
@@ -354,7 +354,7 @@ smmap==5.0.1
     # via gitdb
 sniffio==1.3.1
     # via anyio
-soupsieve==2.5
+soupsieve==2.6
     # via beautifulsoup4
 stack-data==0.6.3
     # via ipython
@@ -410,7 +410,7 @@ urllib3==2.2.2
     #   requests
 wcwidth==0.2.13
     # via prompt-toolkit
-webcolors==24.6.0
+webcolors==24.8.0
     # via jsonschema
 webencodings==0.5.1
     # via


### PR DESCRIPTION
This updates `civis-jupyter-notebook` to v2.2.1 in order to fix terminal access. See https://github.com/civisanalytics/civis-jupyter-notebook/pull/58.

[Here's](https://platform.civisanalytics.com/spa/#/notebooks/36195?expanded=true) an internal test notebook for this branch. It loaded up fine, and the terminal worked for me.

---

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed